### PR TITLE
feat: add property 'kind' into CaptionTrack

### DIFF
--- a/lib/src/caption_track.dart
+++ b/lib/src/caption_track.dart
@@ -4,6 +4,7 @@ class CaptionTrack {
     required this.baseUrl,
     required this.name,
     required this.languageCode,
+    required this.kind,
   });
 
   /// Base URL of the caption track. This is used to get actual subtitles.
@@ -15,6 +16,9 @@ class CaptionTrack {
   /// The language code of the caption track.
   final String languageCode;
 
+  /// The kind of the caption track. The kind of a caption track generated using automatic speech recognition will be 'asr'.
+  final String kind;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -22,13 +26,14 @@ class CaptionTrack {
     return other is CaptionTrack &&
         other.baseUrl == baseUrl &&
         other.name == name &&
-        other.languageCode == languageCode;
+        other.languageCode == languageCode &&
+        other.kind == kind;
   }
 
   @override
-  int get hashCode => baseUrl.hashCode ^ name.hashCode ^ languageCode.hashCode;
+  int get hashCode => baseUrl.hashCode ^ name.hashCode ^ languageCode.hashCode ^ kind.hashCode;
 
   @override
   String toString() =>
-      'CaptionTrack(baseUrl: $baseUrl, name: $name, languageCode: $languageCode)';
+      'CaptionTrack(baseUrl: $baseUrl, name: $name, languageCode: $languageCode, kind: $kind)';
 }

--- a/lib/src/dtos.dart
+++ b/lib/src/dtos.dart
@@ -5,6 +5,7 @@ class CaptionTrackDto {
     required this.baseUrl,
     required this.name,
     required this.languageCode,
+    required this.kind,
   });
 
   factory CaptionTrackDto.fromJson(Map<String, dynamic> json) {
@@ -12,16 +13,19 @@ class CaptionTrackDto {
       baseUrl: json['baseUrl'],
       name: json['name'] == null ? '' : json['name']['simpleText'],
       languageCode: json['languageCode'],
+      kind: json['kind'] == null ? '' : json['kind'],
     );
   }
 
   final String baseUrl;
   final String name;
   final String languageCode;
+  final String kind;
 
   CaptionTrack toEntity() => CaptionTrack(
         baseUrl: baseUrl,
         name: name,
         languageCode: languageCode,
+        kind: kind,
       );
 }


### PR DESCRIPTION
Add property 'kind' into CaptionTrack and CaptionTrackDto.
This property shows the caption track's type. For example, kind of a caption track generated using automatic speech recognition will be 'asr'. Kind of an official caption track provided by the author will be empty string.