### PR TITLE
Fix parse caption tracks regex

### DIFF
--- a/lib/src/youtube_caption_scraper_impl.dart
+++ b/lib/src/youtube_caption_scraper_impl.dart
@@ -45,12 +45,14 @@ class YouTubeCaptionScraperImpl implements YouTubeCaptionScraper {
   }
 
   List<CaptionTrack> _parseCaptionTracks(String responseBody) {
+    const trailingString = ',"audioTracks"';
     final regex = RegExp(
-      r'({"captionTracks":.*isTranslatable":(true|false)}])',
+      '("captionTracks":.*}]$trailingString)',
     );
     final match = regex.firstMatch(responseBody)!;
-    final matchedData = responseBody.substring(match.start, match.end);
-    final json = jsonDecode('$matchedData}');
+    final matchedData =
+        responseBody.substring(match.start, match.end - trailingString.length);
+    final json = jsonDecode('{$matchedData}');
 
     final List captionTracks = json['captionTracks'];
     return List.generate(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   html: ^0.15.4
-  http: ^0.13.0
+  http: ^1.1.0
 
 dev_dependencies:
   lints: ^2.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   html: ^0.15.4
-  http: ^1.1.0
+  http: ^0.13.0
 
 dev_dependencies:
   lints: ^2.1.1


### PR DESCRIPTION
- The scraping regex wasn't working for me due to the JSON object "captionTracks" data having more fields after "isTranslatable", so I fixed it. It is still compatible with the previous version of data.

- Downgraded the http package because many other projects are dependent on earlier versions of http and it is not needed to have the latest version of http for this project.